### PR TITLE
scripts/test-scripts.sh fix docker compose typo

### DIFF
--- a/scripts/test-script.sh
+++ b/scripts/test-script.sh
@@ -25,7 +25,7 @@ step() {
 
   printf "=== Step %d: %s %s ===\n" "$step" "$operation" "$service"
 
-  docker compose "$operation" "$service"
+  docker-compose "$operation" "$service"
   if [[ "$operation" == "start" ]]; then
     "$path"/wait-for.sh -t 120 "http://localhost:$port/manage/health" -- echo "Host localhost:$port is active"
   fi


### PR DESCRIPTION
If we use ```docker compose``` we will get following error:

```
docker: 'compose' is not a docker command.
```

```docker compose``` is just docker-compose-plugin extension. We should use ```docker-compose``` command always.